### PR TITLE
Reorganizing Community pages

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -4,6 +4,17 @@
     fr: "Communauté"
   items:
     - name:
+        en: Directory of RISM Library Sigla
+        de: RISM Bibliothekssigel
+        fr: Sigle de Bibliothèques RISM
+      link: "/community/sigla.html"
+      items:
+        - name:
+            en: About Sigla
+            de: Über Sigel
+            fr: A propos
+          link: "/community/sigla/about.html"
+    - name:
         en: Muscat
         de: Muscat
         fr: Muscat
@@ -20,33 +31,22 @@
             fr: Ateliers
           link: "/community/muscat/workshops.html"
     - name:
-        en: Directory of RISM Library Sigla
-        de: RISM Bibliothekssigel
-        fr: Sigle de Bibliothèques RISM
-      link: "/community/sigla.html"
-      items:
-        - name:
-            en: About Sigla
-            de: Über Sigel
-            fr: A propos
-          link: "/community/sigla/about.html"
-        - name:
-            en: Help
-            de: Hilfe
-            fr: Aide
-          link: "/community/sigla/help.html"
-    - name:
         en: Data Services
         de: Dataservice
         fr: Services de données
       link: "/community/data-services.html"
     - name:
-        en: "User studies"
+        en: "User Studies"
         de: "Nutzerstudie"
-        fr: "User studies"
+        fr: "User Studies"
       link: "/community/survey.html"
     - name:
         en: "Share Your News with RISM"
         de: "Teilen Sie Ihre Neuigkeiten mit RISM"
         fr: "Share Your News with RISM"
       link: "/community/share-your-news.html"
+    - name:
+        en: "How Can I Participate in RISM?"
+        de: "How Can I Participate in RISM?"
+        fr: "How Can I Participate in RISM?"
+      link: "/community/participate-in-rism.html"

--- a/community.en.md
+++ b/community.en.md
@@ -8,35 +8,22 @@ old_url: http://www.rism.info/en/community.html
 
 # Welcome to the RISM Community!
 
-The RISM Community is the place where contributors and other interested individuals can come together to exchange ideas and information. 
+The RISM database is used by researchers, musicians, librarians, students, music antiquarians, and our active contributors worldwide as a foundation for their work and to contribute new knowledge about the musical past. We have assembled some resources here to enable the wider RISM community to use our tools effectively.
+
 
 {% include image file="/images/community/Community572x300.png" pos="center" %}
 
-## How can I participate in RISM?
-
-We warmly welcome anybody who wants to take part in RISM's projects.  Please contact your country's [national working group](/working-groups.html) or contact the [Editorial Center](/editorial-center.html) for more information.
-
-Individuals can support our work by:
-
-* cataloging sources [directly with RISM](/community/muscat.html) or sending us descriptions of sources not yet in RISM  
-* [reporting mistakes](/service/feedback.html){:target="_blank"} in the online catalog  
-* making us aware of new research concerning sources
-* informing us of performances that involve music found in RISM
-* alerting us to institutions not yet in the [Directory of RISM Library Sigla](/community/sigla.html){:target="_blank"}
-* translating the [RISM brochure](/publications/brochures.html){:target="_blank"} or [Wikipedia articles](https://en.wikipedia.org/wiki/R%C3%A9pertoire_International_des_Sources_Musicales){:target="_blank"} into their local language
-
-[Libraries](/organization/rism-for-libraries.html){:target="_blank"} can support RISM by:
-
-* opening up their collections to RISM contributors
-* supporting their work by offering work space, Internet access, etc.
-* offering staff to work on the project (training is provided free from RISM)
-* [sending RISM data](/community/data-services.html){:target="_blank"} from local catalogs about sources not yet in RISM
-
-Anybody can:
-
-* contribute financially. All donations are welcome! (Receipt provided.)
+- [Directory of RISM Library Sigla](/community/sigla.html): Search RISM’s abbreviations for libraries, archives and collections with historical music holdings, or request a new siglum.  
+- RISM for Researchers (coming soon): Tools for people using RISM for research, scholarship, university projects, or data analysis  
+- [RISM for Librarians](/organization/rism-for-libraries.html): Services for information professionals to support cataloging and metadata as well as reference and instruction.  
+- RISM for Musicians (coming soon): Resources for musicians, performers, conductors, or concert organizers to find original sources for performance.  
+- [Muscat](/community/muscat.html): Information for RISM contributors about our cataloging program, tutorials, and workshops  
+- [Data Services](/community/data-services.html): Ways of using RISM data in external catalogs, projects, or research
+- [User Studies](/community/survey.html): Research carried out by the Editorial Center in 2014–2015 about the users of the RISM Catalog.  
+- [Share Your News with RISM](/community/share-your-news.html): Let us know if you have any discoveries, publications, projects, announcements, or other news that would be of interest to the wider RISM community.
+- [How can I participate in RISM?](/community/participate-in-rism.html): Find out the different ways you can contribute to RISM.
 
 _Images:_  
-(1) Workshop in Shanghai, 2018, sponsored by RISM Chinese-Language Region. Photo by Vivian Zhang.  
-(2, 4) Workshop in Frankfurt sponsored by the Editorial Center, 2018  
-(3) Participants of the conference "Documenting Musical Sources in Latin America," Mainz, 2016  
+(1) Workshop in Shanghai, 2018, sponsored by RISM Chinese-Language Region. Photo: Vivian Zhang  
+(2, 4) Workshop in Frankfurt sponsored by the Editorial Center, 2018. Photo: RISM Zentralredaktion  
+(3) Participants of the conference "Documenting Musical Sources in Latin America," Mainz, 2016. Photo: RISM Zentralredaktion    

--- a/community/participate-in-rism.md
+++ b/community/participate-in-rism.md
@@ -1,0 +1,30 @@
+---
+title: "How Can I Participate in RISM?"
+layout: community
+lang: en
+permalink: /community/participate-in-rism.html
+---
+
+# How Can I Participate in RISM?  
+
+We warmly welcome anybody who wants to take part in RISM's projects.  Please contact your country's [national working group](/working-groups.html) or contact the [Editorial Center](/editorial-center.html) for more information.
+
+Individuals can support our work by:
+
+* Cataloging sources [in the international RISM database](/community/muscat.html) or sending us descriptions of sources not yet in RISM  
+* [Reporting feedback](/service/feedback.html){:target="_blank"} about the online catalogs   
+* Making us aware of [new research concerning sources](/community/share-your-news.html)
+* Informing us of performances that involve music found in RISM
+* Alerting us when a RISM siglum is needed that is not yet in the [Directory of RISM Library Sigla](/community/sigla.html){:target="_blank"}
+* Translating the [RISM brochure](/publications/brochures.html){:target="_blank"} or [Wikipedia articles](https://en.wikipedia.org/wiki/R%C3%A9pertoire_International_des_Sources_Musicales){:target="_blank"} into other languages
+
+[Libraries](/organization/rism-for-libraries.html){:target="_blank"} can support RISM by:
+
+* Opening up their collections to RISM contributors
+* Supporting the work of RISM contributors by offering work space, Internet access, etc.
+* Allotting staff time for RISM cataloging  
+* Updating information about institutions in the [Directory of RISM Library Sigla](/community/sigla.html){:target="_blank"}
+
+Anybody can:
+
+* Contribute financially. All donations are welcome! (Receipt provided.)

--- a/community/sigla.en.md
+++ b/community/sigla.en.md
@@ -13,6 +13,8 @@ RISM assigns an abbreviation, called a library siglum, to institutions worldwide
 
 If an institution is missing from the directory, it has no RISM siglum yet, so [please contact us](mailto:contact@rism.info) and we will create it.  
 
+For assistance in searching the sigla, please see the [Help page](/community/sigla/help.html).
+
 
 <script src="/javascript/sigla2.js"></script>
 <style>

--- a/publications/bibliography.en.md
+++ b/publications/bibliography.en.md
@@ -1094,7 +1094,22 @@ You can find out more about the work of RISM from the following publications:
 
 ### Reviews
 
-_Jump to:_ [Series A/I: Individual Prints before 1800](#series-a) \| [Series A/II: Musical Manuscripts after 1600](#series-aii-musical-manuscripts-after-1600) \| [Series B](#series-b) \| [Series C: Directory of Music Research Libraries](#series-c-directory-of-music-research-libraries) \| [Special Volumes](#special-volumes)
+_Jump to:_ [Online publications](#online-publications) \| [Series A/I: Individual Prints before 1800](#series-a) \| [Series A/II: Musical Manuscripts after 1600](#series-aii-musical-manuscripts-after-1600) \| [Series B](#series-b) \| [Series C: Directory of Music Research Libraries](#series-c-directory-of-music-research-libraries) \| [Special Volumes](#special-volumes)
+
+#### Online publications  
+
+##### RISM Catalog
+
+Balz, Nina. "RISM-Katalog kostenlos online." _Ars Organi: Zeitschrift für das Orgelwesen_ 59, no. 3 (2011): 200-201.  
+
+Colvin, Jenny. "International Inventory of Musical Sources (RISM), http://opac.rism.info." _Music Reference Services Quarterly_ 14, no. 3 (2011): 170-171. [Available online](http://dx.doi.org/10.1080/10588167.2011.597247){:target="_blank"}.  
+
+Tsou, Judy. _Notes_ (June 2011): 789-792. [Available online](https://www.jstor.org/stable/23012840){:target="_blank"}.  
+
+##### RISM Online  
+
+McKay, Cory. “Répertoire International des Sources Musicales (RISM) Digital Center Team. RISM Online”. _Renaissance and Reformation_ 47, no. 1 (2024): 184-91. [Available online](https://doi.org/10.33137/rr.v47i1.43449){:blank}.  
+
 
 #### Series A
 
@@ -1225,13 +1240,6 @@ Rommel, Martina. 6th edition, CD-ROM 4. _Informationsmittel für Bibliotheken_ 7
 
 Popinigis, Danuta. 8th edition, CD-ROM 6. _Muzyka_ 48, no. 1 (2003): 136-143.  
 
-##### RISM Catalog
-
-Balz, Nina. "RISM-Katalog kostenlos online." _Ars Organi: Zeitschrift für das Orgelwesen_ 59, no. 3 (2011): 200-201.  
-
-Colvin, Jenny. "International Inventory of Musical Sources (RISM), http://opac.rism.info." _Music Reference Services Quarterly_ 14, no. 3 (2011): 170-171. [Available online](http://dx.doi.org/10.1080/10588167.2011.597247){:target="_blank"}.  
-
-Tsou, Judy. _Notes_ (June 2011): 789-792. [Available online](https://www.jstor.org/stable/23012840){:target="_blank"}.  
 
 #### Series B
 

--- a/publications/iaml-congresses/2024.en.md
+++ b/publications/iaml-congresses/2024.en.md
@@ -14,7 +14,7 @@ RISM Coordinating Committee
 Working meeting (open)  
 11:00-12:30   
 Chair: Sonia Rzepka (University of Warsaw, Poland)  
-The meeting of the Coordinating Committee is open to RISM contributors and national working group members.
+Open to all: RISM contributors and national working group members as well as anyone wishing to learn more about RISM. The purpose of the meeting will be to provide information on how RISM functions, opportunities for cooperation and to collect suggestions and requests for further RISM functions, the Muscat cataloging application and the public search tools RISM Online and the RISM Catalog.
 
 ## Thursday, June 27
 RISM General Session: Prospects of RISM in Africa—Challenges and opportunities  


### PR DESCRIPTION
- Removing Help from sidebar and adding link to Sigla page
- Putting sigla first in sidebar
- New community text to explain pages
- Moving "how to participate" to new page

Also, Stellenbosch CC meeting description updated, online publications in reviews