### PR TITLE
Update data services page

### DIFF
--- a/community/data-services.en.md
+++ b/community/data-services.en.md
@@ -12,107 +12,67 @@ old_url: http://www.rism.info/en/community/development/data-services.html
 
 {% include image file="/images/community/data-services/grigny-bach.jpg" pos="left" %}
 
-RISM is an international project that documents and describes musical sources. Currently the database contains over one million records that describe sources in detail and may be consulted at [http://opac.rism.info](http://opac.rism.info/){:target="_blank"}.
+RISM is an international project that documents and describes musical sources. Currently the database contains over 1.5 million records that describe sources in detail and may be consulted at [RISM Online](https://rism.online){:target="_blank"} or [http://opac.rism.info](http://opac.rism.info/){:target="_blank"}.
 
-In addition, RISM offers interested libraries and institutions numerous supplemental opportunities for data analysis or to use the data in other projects.
+In addition, RISM offers numerous supplemental opportunities for data analysis or to use the data in other projects.
 
-## Open Data and Linked Open Data
+## Open Data
 
 {% include image file="/images/community/data-services/opendata.png" pos="right" %}
 
-Nearly all of the records may be downloaded as [open data and linked open data](http://opac.rism.info/index.php?id=8&id=8&L=1){:target="_blank"} in MARC XML and RDF format under a Creative Commons CC-BY license at [opac.rism.info](http://opac.rism.info/){:target="_blank"}. In addition to data on musical sources, you will find authority files for people and corporate bodies, and bibliographic data for catalogs of works and secondary literature.  
+RISM releases all data under a [Creative Commons Attribution 3.0 Unported License (CC-BY)](https://creativecommons.org/licenses/by/3.0/){:target="_blank"}. This means that you are free to share and adapt our data with no restrictions, but you must provide public notice and attribution.
+
+## Identifiers
+
+RISM Identifiers are used to uniquely identify individual records for the purposes of referencing and citation in both print and electronic contexts. The "short form" of a RISM Identifier consists of two components: A record type, and the record number, separated by a forward slash. The record type identifes the specific class of the identifer; for example, a record from our person authority or sources. The record number identifies the specific record. This number is unique to the record type. Since we publish both Bibliographic and Authority data in the same systems, both components of the identifier are necessary to uniquely identify all records.
+
+This identifier format is designed to provide an unambiguous short form, so that RISM records may be easily citeable in print and digital publications. It is also designed to be consistent across all the different systems that publish and re-publish RISM data. A consistent identifier format also means that all RISM URL (Universal Resource Locator), so that a record may be retrieved in a web browser, can also serve as the URI for that record, used to identify a particular record in Linked Data systems.
+
+Some examples may help illustrate these concepts. The RISM Identifier for the composer "Barbara Strozzi (1619–1677)" is `people/30009879`. The `people` component identifies the record type, and `30009879` identifies the specific record within the Person authority records. This short form may be used when space is at a premium; for example, in bibliographic citations or footnotes.
+
+This may also be easily resolved to a specific record in RISM Online by adding `https://rism.online/` to the front to form a full URL: `https://rism.online/people/30009879`. This is also a permanent link to the person authority record for Barbara Strozzi. If you are a RISM Cataloger and have access to the Muscat cataloging tool, you can find this record by adding `https://muscat.rism.info/admin/` to the identifier to form the URL `https://muscat.rism.info/admin/people/30009879`.
+
+In addition to serving as a URL, a compact identifier may be used as a type of alias. This is a common practice in Linked Data systems. If we map the compact identifier prefix of `rism:` to `https://rism.online/`, then a full identifier may be constructed as `rism:people/30009879`. Systems that understand compact identifiers can expand this when necessary to form a full URL and URI for this particular record.
+
+All records published by RISM follow these principles. For example, source records such as "Harmonice musices Odhecaton A" may be identified as `sources/993103756`, with all the previously described forms of expansion available for these records.
+
+## MARCXML Downloads
+
+Monthly exports of the RISM data is available for download in MARCXML format on our [Data Exports page](https://rism.digital/exports/index.html){:target="_blank"}.
+
+## Linked Data and Resolution Services.
+
+{% include image file="/images/community/data-services/wikipedia.png" pos="right" %}
+
+RISM Data is available in several Linked Data contexts. Wikidata provides a RISM ID property, [P5504](https://www.wikidata.org/wiki/Property:P5504){:target="_blank"}, that may be used in Wikidata-oriented SPARQL queries. There is also a RISM Siglum property, [P11550](https://www.wikidata.org/wiki/Property:P11550), that can be used as identifiers for institutions that have an assigned [RISM Siglum](https://rism.info/community/sigla.html).
+
+We have a standard prefix and compact identifier, `rism:`, registered with the [Identifiers.org Resolution Service](https://identifiers.org){:target="_blank"}. This can also be used to resolve RISM Identifiers to records in the systems that support these types of identifiers.
+
+For example:
+
+ - Identifiers.org: [http://identifiers.org/rism:people/30002781](http://identifiers.org/rism:people/30002781){:target="_blank"} (Saint-Georges, Joseph Bologne de (1745-1799))
+ - n2t.net: [https://n2t.net/rism:institutions/30078247](https://n2t.net/rism:institutions/30078247){:target="_blank"} (National Library of Ukraine, Music Department)
+
+The RISM Catalog provides the [RISM data in Turtle format](https://opac.rism.info/main-menu-/kachelmenu/data){:target="_blank"} for download and import into Linked Data systems. Note that this data does not follow the RISM Identifiers scheme described above.
+
+## RISM Online API
+
+RISM Online has several web-based APIs (Application Programming Interface) available for public use. Details on how to use these APIs are available in the [RISM Online Documentation](https://rism.online/docs/){:target="_blank"}. For most users this should be the preferred way of accessing and using the RISM Data.
 
 ## SRU Servers
 
 {% include image file="/images/community/data-services/zebra.jpg" pos="left" %}
 
-All catalog entries are available in MARC XML format and are described in accordance with MARC standards. In addition to using the open data interface, different [SRU servers](http://www.loc.gov/standards/sru/){:target="_blank"} can be used to directly [retrieve the data through URLs](http://muscat.rism.info/sru){:target="_blank"} and load them for data harvesting. This allows the information to be presented in the most up-to-date form available. The records are indexed by the free search engine [Zebra](http://www.indexdata.com/zebra){:target="_blank"} through [indexdata.com](http://www.indexdata.com/){:target="_blank"}.
-
-This opens up the possibility of various kinds of searches: full-text, by composer, or specified searches such as by library or other criteria. In addition, SRU search interfaces are available for personal names and libraries.
+The RISM data is also available through our [SRU servers](http://www.loc.gov/standards/sru/){:target="_blank"} which may be used to [retrieve the data](http://muscat.rism.info/sru){:target="_blank"} as MARCXML. Details on how to use this service are available in the [Muscat SRU Service Documentation](https://github.com/rism-digital/muscat/wiki/SRU).
 
 ![SRU](/images/community/data-services/SRU-example.jpg)
-
-## MARC 21 and MARC XML Support
-
-[Machine-Readable Cataloging (MARC)](http://www.loc.gov/marc/){:target="_blank"} is a standardized data format that is used in libraries. It is available in binary as well as computer-readable XML format.
-
-This cataloging format was developed at the Library of Congress in the 1960s and enables computers to exchange bibliographic information with each other. Its data elements form the foundation for most of the library catalogs that are in use today. RISM uses MARC XML for open data as well as SRU for all aspects of data processing, ensuring the best possible portability and flexibility.
-
-![LOC](/images/community/data-services/loc.jpg)
-
-## GND BEACON
-
-{% include image file="/images/community/data-services/wikipedia.png" pos="right" %}
-
-[BEACON](http://meta.wikimedia.org/wiki/BEACON){:target="_blank"} is a very simple file format that is used to display links to websites that offer content on certain authority files. Currently, the format is primarily used for personal names, which are identified by means of a GND (formerly PND) number, although it is suitable for other types of authority files as well.
-
-GND and VIAF BEACON files for personal names and institutions. Several projects have already integrated RISM's BEACON data:
-
-* The [Neue Deutsche Biographie](http://www.deutsche-biographie.de/index.html){:target="_blank"} (New German Biography)
-* Wikipedia's [Personensuche](http://toolserver.org/~apper/pd/){:target="_blank"} (People Search)
-* The [Bayerisches Musiker-Lexikon Online](http://www.bmlo.lmu.de/){:target="_blank"} (Bavarian Online Dictionary of Musicians)
-
-The BEACON files can be found through the [RISM Catalog](https://opac.rism.info/main-menu-/kachelmenu/data){:target="_blank"}.  
-
-![NDB](/images/community/data-services/NDB.jpg)
-
-## Custom Displays of Data
-
-Through the use of RISM's SRU search interface, you have the opportunity to create a customized web-based catalog based on any subset of the RISM data, such as for a particular library or country. In such cases, the SRU interface serves solely as the back-end infrastructure. Individual solutions are thus possible in cooperation with RISM.
-
-Dokumentation and examples on the SRU interface can be found [here](https://github.com/rism-ch/muscat/wiki/SRU){:target="_blank"}.
-
-## Data Transfers
-
-As long as your data are available in a structured form, RISM can convert them into MARC XML and integrate them into the data pool. So far, we have converted files from Microsoft Access databases, Word documents, and plaintext files. A converter for UNIMARC is in preparation. The conversion process is presented in a straightforward, web-based manner:  through our own RISM Toolkit application, the imported file is displayed in a test environment before it is incorporated into the larger data pool.
-
-## Catalog Printouts of RISM Data
-
-{% include image file="/images/community/data-services/katalog-friedemann.jpg" pos="right" %}
-
-### Introduction
-Generating a catalog of entries from the [RISM database](https://opac.rism.info/index.php?id=4){:blank} is a convenient way of presenting a subset of the RISM data in a more tangible form, which would otherwise be less immediately perceptible in an extensive database consisting of 1.5 million records. This option is most frequently used to facilitate the publication of a printed catalog, to document the completion of a cataloging project for funding partners, or to allow for a review and potential correction of the catalog descriptions. Since 1996, the RISM Editorial Center has offered its partners this option, though the technical implementation has of course changed a good deal in recent years. Over the years the Editorial Center has been involved in approximately 30 different publication projects of varying scope. While the first catalogs were created using macros with Microsoft Word for Windows, the Kallisto cataloging program introduced a shift to camera-ready copy with the document preparation program LaTeX. Since an SRU interface had been an integral part of the cataloging software Muscat since 2017, we developed a solution in which both the basic software and the interface are freely accessible. This ensures that an automated, high-performance, and, above all, high-quality catalog printout is available to everyone in PDF format without additional costs.
-
-
-### Description
-Records that are already published in the RISM catalog can be downloaded at any time using the [Muscat SRU interface](https://github.com/rism-international/sru-downloader){:blank}. Here it should be kept in mind that the SRU interface uses a pager method, so each retrieval is limited to a maximum of 100 hits—a customary value for SRU interfaces. Through standardized SRU interfaces, data can be queried and exchanged by machine. A good introduction to this is available on the [website of the Library of Congress](http://www.loc.gov/standards/sru/){:blank}. The RISM Editorial Center provides a cross-platform Java tool that downloads the SRU query as a MARCXML file. For the catalog generator, an additional processing step retrieves the data from the SRU interface and converts it to LaTeX files using an XSLT processor, and following this, indexes are also created. The framework for this conversion is a Ruby application, which allows for a system-independent installation. In developing this tool, we gave priority to cross-platform modules. All components of the PDF catalog generator run equally well with Windows and Linux.  
-
-At the heart of the PDF generator lies a LaTeX processor that processes the tex files, in this case LuaLaTeX. Please ensure that all necessary modules are correctly and entirely installed in advance; this aspect may occasionally prove the biggest hurdle when using the catalog program. Full installation instructions and the open source code are [available on GitHub](https://github.com/rism-international/pdf-export){:blank}. Instructions are available there for Linux and Microsoft Windows (version 10).  
-
-### Music Incipits
-While converting data to tex files might seem relatively straightforward, embedding music incipits into the catalog is considerably more complicated. The catalog program embeds the Plaine & Easie code in the tex file. Then the LaTeX processor calls up Verovio as an external program to create the graphics, in SVG for the highest resolution. Verovio is a standard tool for rendering high-quality incipits in Plaine & Easie, which is also used in Muscat. At the same time, the incipit graphics must be cropped so that overly long incipits do not run over the span of the column. Verovio can be called in two ways: either as a JavaScript module in the node.js runtime environment or as a binary file; the latter has significant gains in performance. In order to run Verovio as a binary file, however, it must first be compiled. Instructions can be found [on the Verovio website](https://www.verovio.org/index.xhtml){:blank} or the GitHub repository associated with it. Integrating these SVG graphics into the LaTeX document is in turn done through Inkscape, a program for editing vector graphics (see the [Wikipedia article](https://en.wikipedia.org/wiki/Inkscape){:blank} or [GitHub](https://github.com/mrpiggi/svg){:blank}. In the following example, these lines of instruction would look like this in the complete LaTeX file:  
-
-```
-1 \begin{filecontents*}{1-1.code}  
-2 @clef:G-2  
-3 @keysig:bB  
-4 @timesig:4/4  
-5 @data:{8DEFD}/4BBB{8AG}/{FE}4D8{FGAF}/''4DDD{8C'B}/{AG}4F{8B''CD'A}/  
-6 \end{filecontents*}  
-7 \ShellEscape{ if [ ! -f 1-1.svg ]; then verovio --spacing-non-linear=0.54 -w 1500 --spacing-system=0.5 --adjust-page-height -b 0 1-1.code; fi }  
-8 \newline \includesvg[width=209pt]{1-1}%  
-```
-
-Lines 1-6 contain the Plaine & Easie code of the music incipit, in line 7 Verovio creates the graphic file with defined parameters, and in the final line this SVG graphic is integrated into the document via Inkscape.  
-
-### Catalog Settings
-As a default, catalogs are created with English headings and the page layout is in two columns in DIN-A4 format. The records are sorted by composer, then title, with collections appearing at the end.  
-
-Thanks to the high flexibility of the program, basically all of the settings can be changed so that, for example, a different printing area or a different font can be employed.  
-
-The time needed to generate the catalog depends to a large extent on the performance of the computer being used. Using typical hardware, about two hours are needed to create a catalog of all Bach sources in RISM: about 20,000 records on 5,700 pages, a file of 150 MB. By far the greatest part of computing time is taken up by rendering the graphics.  
-
-### Looking Ahead
-Although all the components used and described above have already been made publicly available, the Editorial Center still has to handle a considerable number of requests for assistance. In such cases, we can only assist with catalogs that use the standard settings. Looking at further development of the program, we are planning to integrate it into Muscat, so that users can spare themselves the trouble of the rather demanding installation and produce catalogs independently. Complex additional requests, however, such as changes in sorting, must be handled by the users on their own, and this will likely remain so even after it is part of Muscat as well.
 
 _Photo credits:_
 
 1. Organ piece by Nicolas de Grigny, "1er Kyrie en taille," in the hand of J. S. Bach, [D-F Mus Hs 1538](http://opac.rism.info/search?documentid=455002348){:target="_blank"}
 2. Open data logo: own work
-3. Zebra via [indexdata.com](http://www.indexdata.com/zebra){:target="_blank"}
 4. SRU file: own work
 5. MARC logo: Library of Congress, ["MARC Standards"](http://www.loc.gov/marc/){:target="_blank"}
 6. Main Reading Room, Library of Congress, Washington, DC, by Carol M. Highsmith, via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:LOC_Main_Reading_Room_Highsmith.jpg){:target="_blank"}
 7. Wikipedia logo via [wikipedia.org](http://www.wikipedia.org/){:target="_blank"}
 8. [Neue Deutsche Biographie](http://www.deutsche-biographie.de/index.html){:target="_blank"}
-9. Catalog PDF: own work


### PR DESCRIPTION
This PR adds updates to the data services page to reflect new means of accessing and using the RISM data.

Notable changes include:

1. A new section on the structure and use of RISM identifiers.
2. A re-ordering of sections to reflect relative topical importance
3. Updated links to the MARCXML downloads
4. Removal of the GND BEACON section, since maintenance of this data seems to have stalled
5. Addition of a couple paragraphs of RISM data in Wikidata and in resolver services
6. Removal of the section on the details of producing printed catalogues. This seems to be described at https://rism.info/community/rism-for-researchers.html, and it covered topics that were not necessarily of interest to people who would request this.

Things that could be changed but weren't (subject to discussion):

 - The RISM `ARK` prefix: `ark:/33864`. @lpugin do we want to advertise this? 
 - More detail on individual services. For services that have their own documentation (RISM Online, SRU) I point to the specific documentation of this service for more details, rather than repeating it here. It's one fewer place we need to keep updated when things change.
 
I imagine that this will also need to be translated to German after the final text is agreed on.