### PR TITLE
Add post about Renaissance notation knives

### DIFF
--- a/_posts/en/2025-11/2025-11-13-musical_knives
+++ b/_posts/en/2025-11/2025-11-13-musical_knives
@@ -1,0 +1,31 @@
+---
+layout: post
+title: Renaissance notation knives
+date: 2025-11-13
+lang: en
+post: true
+category: library_collections
+image: "/images/news/2025-11/musical-knives-serving-knife-US-PHmoa-contratenor.jpg"
+email: ''
+author: ''
+---
+
+If you reach into more remote corners of the RISM database, you will find music that won’t exactly fit on your music stand. Back in 2013 we shared a [musical table](https://rism.info/rediscovered/2013/10/22/musical-tables.html){:blank} with you, an etched slab of stone containing the two-part motet “Solve jubente Deo” for six voices by Giovanni Pierluigi da Palestrina. The music is laid out on the table in a way that would allow the motet to be sung if the singers are grouped around the table.
+The five musical tables in RISM can be found by searching for “Notation tables.”  
+([RISM Catalog](https://opac.rism.info/search?View=rism&q=notation+tables){:blank} \| [RISM Online](https://rism.online/search?q=notation%20tables&mode=sources&fq=subjects%3ANotation%20tables&page=1&rows=20){:blank})
+
+Staying with a domestic theme, today we are going from musical tables to musical knives. “Notation knives” (as museums categorize them) are knives where the blades are engraved with music notation.  They originally were produced in sets, with one knife per voice part. The metal knife blades are long and wide enough to contain a full staff line of music, including text. As is appropriate for the dining setting, music for a benediction is on one side of the blade, to be sung before the meal, and a grace is on the other side, to be sung after the meal.
+Art historian and musicologist Flora Dennis has identified 20 knives that fall into this category of notation knives, though four of those are only known through 19th-century publications. Her research on this special silverware can be found in “Scattered knives and dismembered song: cutlery, music and the rituals of dining” ([_Renaissance Studies_ 24, no. 1 (February 2010): 156-184]https://doi.org/10.1111/j.1477-4658.2009.00634.x) and most recently in the “Knife” chapter of ([_The Museum of Renaissance music: A history in 100 exhibits_ (Brepols, 2023)] https://www.brepols.net/products/IS-9782503588568-1). The knives were likely produced in Italy around 1550.
+Dennis groups the knives into two sets according to the music, Group A and Group B. All knives from both groups may have once have been a part of a much larger cutlery set. The polyphonic music in Group A is for six voices (Superius 1, 2, Contratenor, Tenor 1, 2, Bassus), though no knife for Superius 1 has been located. The music in Group B is for four parts (Superius, Contratenor, Tenor, Bassus).
+
+{% include image file="/images/news/2025-11/musical-knives-serving-knife-va-tenor.jpg" %}
+Serving knife, ca. 1550, depicting the Tenor part of the “Benedictio mensae” (RISM ID no. 1001303444). [(GB-Lv) 310-1903](https://collections.vam.ac.uk/item/O110614/serving-knife-unknown/) © Victoria and Albert Museum, London
+
+The benediction is headed “Benedictio mensae” on the blade. The text reads, "Quae sumpturi sumus benedicat trinus et unus." The other side of the blade is the table grace, called “Gratiarum actio" with the text "Pro tuis deus beneficiis gratias agimus tibi” (or the variation “Pro tuis beneficiis deus...”). Both of these kinds of table prayers can be found in other sources in the RISM database, but the exact text on the knives does not match other text incipits in the RISM database. The composer of the music has not been identified.
+Though the material is unusual, the music on the knives certainly fits with other documents in the RISM database and tells a story of musical transmission and everyday use. We have cataloged the knives the same way as how we describe printed music editions in our database. Though not produced with ink, the knives resemble their paper counterparts insofar that each knife takes up the role of a different partbook, some "partbooks" are preserved in multiple copies, and the knives are currently located in disparate collections in Europe and the United States. We follow Dennis's Group A (RISM ID no. 1001303439) and Group B (RISM ID no. 1001303503). “Notation knives” as a keyword was added to the database.
+Flora Dennis includes a full transcription of the music in her article in _Renaissance Studies_. Images of most of the knives are reproduced there as well, and since the article is freely available online, we have linked to the images in the RISM records.
+Though the decorative elements set these knives apart, we can surmise that they also filled their function as utilitarian objects. Indeed, one of the knives has surfaces so worn away that the music is no longer legible. The knives can carve meat and are wide enough for serving. A person using the knives for performance would have to hold the knife in the left hand, with the blade pointing down, in order to read the music.
+Below, Kirstin Kennedy from the Victoria and Albert Museum gives us an up-close look at the collection’s knives and Flora Dennis talks about the music. https://youtu.be/-mai-7WUbBo
+<iframe width="560" height="315" src="https://www.youtube.com/embed/-mai-7WUbBo?si=CKvy7Nxi8lZfEtLo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+ 
+Image: Serving Knife with Musical Notation and Prayers of Grace and Benediction, ca. 1550, depicting the Countertenor part of the “Pro tuis deus beneficiis gratias agimus tibi.” Philadelphia Museum of Art, Philadelphia, PA (US-PHmoa 1930-1-127. RISM ID no. 1001303495. Available online https://www.philamuseum.org/collection/object/161048 (public domain).


### PR DESCRIPTION
This post explores the concept of 'notation knives,' which are engraved with music notation and were used in dining settings. It discusses their historical context, the music they feature, and their significance in the study of musical transmission.