### PR TITLE
Add Linked RISM paper; standardize time format

### DIFF
--- a/publications/iaml-congresses/2026.en.md
+++ b/publications/iaml-congresses/2026.en.md
@@ -14,11 +14,11 @@ RISM will be involved in the following sessions:
 ## Tuesday, 30 June         
 Two-part introductory cataloging workshop on [Muscat](/community/muscat.html), RISM’s cataloging program for documenting musical sources. The workshop is suitable for anyone curious about RISM's cataloging standards or interested in starting their own RISM cataloging projects at their institutions. Muscat is a web-based, platform-independent, and open-source program that is available free of charge. Space is limited. Please register by sending an e-mail to [contact@rism.info](mailto:contact@rism.info). **Partipants must bring their own laptops.**  
 
-- 9.00–10.30       
+- 9:00–10:30       
 RISM Workshop 1: Muscat basics   
 The first part of the Muscat workshop will focus on basic Muscat editing skills for librarians and how to cataloging music manuscripts in Muscat. RISM encourages librarians to include music manuscripts from any time period up to the present and printed music until ca. 1945, as well as libretti and treatises.   
 
-- 11.00–12.30   
+- 11:00–12:30   
 RISM Workshop 2: Continuation  
 This course will continue the skills learned in the morning's RISM Workshop 1. We will practice cataloging manuscript collections and go into some of the details involving cataloging printed music. Basic knowledge of Muscat is required, either from the morning session or participation in a previous Muscat workshop.
 
@@ -46,5 +46,9 @@ Chair: Sonia Rzepka (University of Warsaw)
 
 ## Friday, 3 July    
 
-- 11.00-12.30  
+- 9:00-9:30  
+Linked RISM: 91 million triples and growing  
+Andrew Hankinson, Laurent Pugin (RISM Digital Center)
+
+- 11:00-12:30  
 Commission Mixte (closed working meeting)  


### PR DESCRIPTION
- Adds the Linked RISM paper to the list
- Standardizes the time format (mix of periods and colons; chose colons since that seems to be more correct?)