### PR TITLE
Add GND-Editor details to the blog post

### DIFF
--- a/_posts/de/2026-07 /2026-07-24-GND-Editor.md
+++ b/_posts/de/2026-07 /2026-07-24-GND-Editor.md
@@ -9,6 +9,7 @@ image: "/images/news/2026-07/logos_untereinander.jpg"
 email: 'Alexander.Faschon@slub-dresden.de'
 author: 'Alexander Faschon und Desiree Mayer'
 ---
+
 _Den folgenden Beitrag stellten uns freundlicherweise Alexander Faschon und Desiree Mayer zur Verfügung. Beide sind angestellt bei der Sächsischen Landesbibliothek - Staats- und Universitätsbibliothek Dresden (SLUB), wo sie die musikwissenschaftlichen Projekte innerhalb des NFDI4Culture-Konsortiums betreuen._ 
 
 Seit Anfang 2026 ist eine neue Komponente in Muscat fertiggestellt: Der GND-Editor zum Erstellen von GND-Werknormsätzen. Hervorgegangen aus einer Kooperation zwischen dem RISM Digital Center, der Deutschen Nationalbibliothek und dem Konsortium [NFDI4Culture](https://nfdi4culture.de/de/index.html){:blank}, markiert der Editor für RISM eine wichtige Station auf dem Weg der Normdatenanbindung. Das neue Tool erlaubt das Anlegen von GND (Gemeinsame Normdatei) -Normsätzen zu Werken der Musik aus Muscat heraus. Die folgenden Ausführungen skizzieren die technischen Eigenschaften des GND-Editors und ordnen ihn in die aktuellen RISM-Aktivitäten rund um die Werkebene ein. 


### PR DESCRIPTION
Introduced the GND-Editor for creating GND norms for music works, detailing its technical features and relevance to RISM activities.